### PR TITLE
remove 'transmission' dependency:

### DIFF
--- a/nethserver-transmission.spec
+++ b/nethserver-transmission.spec
@@ -15,7 +15,7 @@ BuildRoot: /var/tmp/%{name}-%{version}-buildroot
 BuildRequires: nethserver-devtools
 Requires: nethserver-ibays nethserver-samba nethserver-httpd
 Requires: mod_authnz_pam
-Requires: transmission, transmission-cli, transmission-common, transmission-daemon
+Requires: transmission-cli, transmission-common, transmission-daemon
 AutoReqProv: no
 
 %description


### PR DESCRIPTION
we do not need the dektop-gui,
transmission-{cli, common, daemon} is sufficient for web-gui

Hi Stephane,

Thanx for this nethserver-module! 
At install I noticed it pulls in all kind of (GTK) destkop stuff we do not need. Installed size without it is reduced by about 20 MB. 
Build and tested this , works just fine without the bare transmission package!